### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tessel/climate-si7020"
+    "url": "git@github.com:tessel/climate-si7020.git"
   },
   "readmeFilename:" : "README.md",
   "directories": {


### PR DESCRIPTION
- Previously, `npm install` output:

```
npm WARN package.json climate-si7020@0.1.0 No repository field.
```
