### PR TITLE
Removes connect method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ climate.on('error', function(err) {
 
 ## Methods
 
-*  **`climate`.connect(interface[, csn])**
-Takes in the port bank that the module is connected to. Returns the Climate object.
-
 *  **`climate`.readTemperature([format,] callback(err, temp))**
 Returns the temperature in degrees Celcius or Fahrenheit.
 


### PR DESCRIPTION
The README listed `connect` instead of `use`. All of the other modules don't specifically document the `lib.use` function so I'm making this README consistent.